### PR TITLE
Fix invalid constants in patterns

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -4,7 +4,7 @@ use core::fmt;
 pub const ELF_MAGIC: &'static [u8] = &[0x7f, 'E' as u8, 'L' as u8, 'F' as u8];
 
 /// Represents the ELF file class (32-bit vs 64-bit)
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Class(pub u8);
 
 /// Invalid ELF file class
@@ -33,7 +33,7 @@ impl fmt::Display for Class {
 }
 
 /// Represents the ELF file data format (little-endian vs big-endian)
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Data(pub u8);
 
 /// Invalid ELF data format
@@ -461,7 +461,7 @@ impl fmt::Display for ProgFlag {
 }
 
 /// Represents ELF Program Header type
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct ProgType(pub u32);
 
 /// Program header table entry unused
@@ -546,7 +546,7 @@ impl fmt::Display for ProgramHeader {
 }
 
 /// Represens ELF Section type
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct SectionType(pub u32);
 
 /// Inactive section with undefined values
@@ -727,7 +727,7 @@ impl fmt::Display for SectionHeader {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct SymbolType(pub u8);
 
 /// Unspecified symbol type
@@ -764,7 +764,7 @@ impl fmt::Display for SymbolType {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct SymbolBind(pub u8);
 
 /// Local symbol
@@ -789,7 +789,7 @@ impl fmt::Display for SymbolBind {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct SymbolVis(pub u8);
 
 /// Default symbol visibility


### PR DESCRIPTION
Not sure if this crate is abandoned or not, but it's going to be broken by an upcoming bugfix in rustc. This PR adds the property of structural equality to several structs so constants of their types can be used in patterns.
See https://github.com/rust-lang/rust/issues/36891 and rust-lang/rust#36894 for more details.