### PR TITLE
fix: fixed symbol table read for 32 bit binaries for issue #10

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,6 +291,12 @@ impl<'s> ElfBinary<'s> {
                 func(entry);
             }
             Ok(())
+        } else if let SectionData::SymbolTable32(entries) = symbol_table {
+            for entry in entries {
+                //trace!("entry {:?}", entry);
+                func(entry);
+            }
+            Ok(())
         } else {
             Err(".symtab does not contain a symbol table")
         }


### PR DESCRIPTION
This is a fix for issue #10. The problem was reading of 32 bit symbol table was not handled in code